### PR TITLE
Fetch recipe specific info from API to display on modal

### DIFF
--- a/express-server/app.js
+++ b/express-server/app.js
@@ -12,10 +12,18 @@ app.use(express.json())
 app.use(morgan("tiny"))
 app.use(cors())
 
+// fetches best recipes given user food items from API
 app.get('/apirecipes/:ingredients', async (request, response) => {
-    const recipes_url = `https://api.spoonacular.com/recipes/findByIngredients?ingredients=${request.params.ingredients}&number=20&apiKey=${api_key}`;
+    let recipes_url = `https://api.spoonacular.com/recipes/findByIngredients?ingredients=${request.params.ingredients}&number=20&instructionsRequired=true&fillIngredients=true&apiKey=${api_key}`;
     let { data } = await axios(recipes_url)
     response.json(data);
-  });
+});
+
+// fetches recipe specific info given recipe id from API
+app.get('/apirecipeinfo/:recipeid', async (request, response) => {
+    let recipes_url = `https://api.spoonacular.com/recipes/${request.params.recipeid}/information?apiKey=${api_key}`;
+    let { data } = await axios(recipes_url)
+    response.json(data);
+});
 
 module.exports = app

--- a/express-server/app.js
+++ b/express-server/app.js
@@ -14,15 +14,25 @@ app.use(cors())
 
 // fetches best recipes given user food items from API
 app.get('/apirecipes/:ingredients', async (request, response) => {
-    let recipes_url = `https://api.spoonacular.com/recipes/findByIngredients?ingredients=${request.params.ingredients}&number=20&instructionsRequired=true&fillIngredients=true&apiKey=${api_key}`;
-    let { data } = await axios(recipes_url)
+    const params = {
+        ingredients: request.params.ingredients,
+        number: 20,
+        instructionsRequired: true,
+        fillIngredients: true,
+        apiKey: api_key
+    }
+    let recipes_url = "https://api.spoonacular.com/recipes/findByIngredients";
+    let { data } = await axios(recipes_url, { params })
     response.json(data);
 });
 
 // fetches recipe specific info given recipe id from API
 app.get('/apirecipeinfo/:recipeid', async (request, response) => {
-    let recipes_url = `https://api.spoonacular.com/recipes/${request.params.recipeid}/information?apiKey=${api_key}`;
-    let { data } = await axios(recipes_url)
+    const params = {
+        apiKey: api_key
+    }
+    let recipes_url = `https://api.spoonacular.com/recipes/${request.params.recipeid}/information`;
+    let { data } = await axios(recipes_url, { params })
     response.json(data);
 });
 

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,7 +4,6 @@ import Profile from "../Profile/Profile"
 import Recipes from "../Recipes/Recipes"
 import Pantry from "../Pantry/Pantry"
 import ShoppingCart from "../ShoppingCart/ShoppingCart"
-import { constRecipes, constRecipeInstructions, constRecipeInfo } from "../constants/constants"
 import './App.css';
 
 import { BrowserRouter, Routes, Route } from "react-router-dom"
@@ -36,18 +35,13 @@ export default function App() {
     quantity: ""
   }
 
-  //TODO: replace these placeholders once we integrate with the recipe API
-  const sampleRecipeInstructions = constRecipeInstructions
-
-  const sampleRecipeInfo = constRecipeInfo
-
   const recipeApiUrl = "http://localhost:3001/apirecipes/"
+  const recipeInfoUrl = "http://localhost:3001/apirecipeinfo/"
 
 // state variables
 const [products, setProducts] = useState(basicProducts)
 const [productForm, setProductForm] = useState(basicProductForm)
 const [recipeModelShow, setRecipeModalShow] = useState(false)
-const [recipeInstructions, setRecipeInstructions] = useState([])
 const [recipeInfo, setRecipeInfo] = useState({})
 const [recipes, setRecipes] = useState([])
 
@@ -142,9 +136,9 @@ const handleOnProductFormChange = (event) => {
 }
 
 // onclick function for each recipe card
-const handleRecipeCardClick = (showStatus, recipeId) => {
+const handleRecipeCardClick = async (showStatus, recipeId) => {
+  await handleGetRecipeInstructions(recipeId)
   handleRecipeModal(showStatus)
-  handleGetRecipeInstructions(recipeId)
 }
 
 // pop up recipe modal for specific recipe card
@@ -152,11 +146,15 @@ const handleRecipeModal = (showStatus) => {
   setRecipeModalShow(showStatus)
 }
 
-// extract recipe instructions for recipe modal
-const handleGetRecipeInstructions = (recipeId) => {
-  //TODO: extract recipe instructions for specific given recipe using API
-  setRecipeInstructions(sampleRecipeInstructions)
-  setRecipeInfo(sampleRecipeInfo)
+// extract recipe info from backend for recipe modal
+const handleGetRecipeInstructions = async (recipeId) => {
+  try {
+    var { data } = await axios(recipeInfoUrl + recipeId)
+    setRecipeInfo(data)
+  } catch (error) {
+    console.log("error in fetching from backend")
+  }
+  
 }
 
   return (
@@ -167,7 +165,7 @@ const handleGetRecipeInstructions = (recipeId) => {
           <Routes>
             <Route path="/" element={<Home />}/>
             <Route path="/profile" element={<Profile />}/>
-            <Route path="/recipes" element={<Recipes recipeInfo={recipeInfo} handleRecipeCardClick={handleRecipeCardClick} recipeInstructions={recipeInstructions} handleRecipeModal={handleRecipeModal} recipeModelShow={recipeModelShow} recipes={recipes}/>}/>
+            <Route path="/recipes" element={<Recipes recipeInfo={recipeInfo} handleRecipeCardClick={handleRecipeCardClick} handleRecipeModal={handleRecipeModal} recipeModelShow={recipeModelShow} recipes={recipes}/>}/>
             <Route path="/pantry" element={<Pantry operations={Operations} productForm={productForm} handleOnProductFormChange={handleOnProductFormChange} handleOnSubmitProductForm={handleOnSubmitProductForm} handleProductQuantity={handleProductQuantity} products={products}/>}/>
             <Route path="/shoppingcart" element={<ShoppingCart />}/>
           </Routes>

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -35,7 +35,7 @@ export default function App() {
     quantity: ""
   }
 
-  const recipeApiUrl = "http://localhost:3001/apirecipes/"
+  const listRecipeUrl = "http://localhost:3001/apirecipes/"
   const recipeInfoUrl = "http://localhost:3001/apirecipeinfo/"
 
 // state variables
@@ -58,10 +58,11 @@ useEffect(() => {
     try {
       // API parameter format: ingredient,+ingredient,+ingredient
       let ingredientParams = products.map((product) => (product.name)).join(",+")
-      const recipeApiIngredients = recipeApiUrl + ingredientParams
+      const recipeApiIngredients = listRecipeUrl + ingredientParams
       var { data } = await axios(recipeApiIngredients)
       setRecipes(data)
     } catch (err) {
+      //TODO: error handling
       console.log("error in fetching from backend")
     }
   }
@@ -152,6 +153,7 @@ const handleGetRecipeInstructions = async (recipeId) => {
     var { data } = await axios(recipeInfoUrl + recipeId)
     setRecipeInfo(data)
   } catch (error) {
+    //TODO: error handling
     console.log("error in fetching from backend")
   }
   

--- a/src/components/RecipeCard/RecipeCard.jsx
+++ b/src/components/RecipeCard/RecipeCard.jsx
@@ -11,7 +11,7 @@ export default function RecipeCard(props) {
         <img src={props.image} alt={`recipe for ${props.title}`} onClick={() => props.handleRecipeCardClick(true, props.id)}/>
         <p className="recipe-name">{props.title}</p>
         {/* recipe modal */}
-        <RecipeModal show={props.recipeModelShow} onHide={() => props.handleRecipeModal(false)} title={props.title} instructions={props.recipeInstructions} recipeInfo={props.recipeInfo}></RecipeModal>
+        <RecipeModal show={props.recipeModelShow} onHide={() => props.handleRecipeModal(false)} recipeInfo={props.recipeInfo}></RecipeModal>
     </div>
   )
 }

--- a/src/components/RecipeModal/RecipeModal.jsx
+++ b/src/components/RecipeModal/RecipeModal.jsx
@@ -7,12 +7,12 @@ export default function RecipeModal(props) {
     if (!props.show) {
         return null
     }
-    const { recipeInfo, instructions, title, ...modalProps } = props
+    const { recipeInfo, ...modalProps } = props
     return (
       <Modal {...modalProps} scrollable={true} size="lg" aria-labelledby="contained-modal-title-vcenter" centered>
         <Modal.Header closeButton>
           <Modal.Title id="contained-modal-title-vcenter">
-            {title}
+            {recipeInfo.title}
           </Modal.Title>
         </Modal.Header>
         <Modal.Body className="show-grid">
@@ -42,7 +42,7 @@ export default function RecipeModal(props) {
                     <p className="modal-headings">Steps:</p>
                     {
                         // props.instructions is array of instruction Objects, main instruction is at index 0
-                        instructions[0].steps.map((curStep) => (
+                        recipeInfo.analyzedInstructions[0].steps.map((curStep) => (
                             <p key={curStep.number}>{curStep.number}. {curStep.step}</p>
                         ))
                     }

--- a/src/components/Recipes/Recipes.jsx
+++ b/src/components/Recipes/Recipes.jsx
@@ -11,7 +11,7 @@ export default function Recipes(props) {
       <div className="recipes-grid">
         {
           props.recipes.map((recipe) => (
-            <RecipeCard key={recipe.id} id={recipe.id} title={recipe.title} image={recipe.image} recipeModelShow={props.recipeModelShow} handleRecipeModal={props.handleRecipeModal} handleRecipeCardClick={props.handleRecipeCardClick} recipeInstructions={props.recipeInstructions} recipeInfo={props.recipeInfo}/>
+            <RecipeCard key={recipe.id} id={recipe.id} title={recipe.title} image={recipe.image} recipeModelShow={props.recipeModelShow} handleRecipeModal={props.handleRecipeModal} handleRecipeCardClick={props.handleRecipeCardClick} recipeInfo={props.recipeInfo}/>
           ))
         }
       </div>


### PR DESCRIPTION
- When user clicks on a recipe, frontend sends the recipe id to an endpoint
- backend gets recipe id and fetches recipe info from API
- frontend displays the recipe info (ingredients and instructions) on the modal

Note: I initially had a separate variable for recipe info (containing ingredients) and recipe instructions since some of the recipes didn't have instructions in the data when I fetched the data. I fixed this by only displaying recipes that had instructions in the first place, and combined recipe ingredients and instructions into one fetch and one variable

screenshot of recipe specific modal:
<img width="1101" alt="Screen Shot 2022-07-08 at 4 33 20 PM" src="https://user-images.githubusercontent.com/62860690/178082258-64f42bb2-1592-4c0a-a3bc-b04a891cb4e3.png">
 