### PR TITLE
Fetch filtered recipes based on user profile

### DIFF
--- a/express-server/app.js
+++ b/express-server/app.js
@@ -2,7 +2,6 @@ const express = require("express")
 const axios = require('axios')
 const morgan = require("morgan")
 const cors = require("cors")
-const { parseActionCodeURL } = require("firebase/auth")
 
 const app = express()
 
@@ -13,19 +12,18 @@ app.use(morgan("tiny"))
 app.use(cors())
 
 // fetches best recipes given user food items from API
-app.get('/apiuserrecipes/:ingredients/:diets/:allergies', async (request, response) => {
+app.get('/listapirecipes/:sort/', async (request, response) => {
     let params = {
-        includeIngredients: request.params.ingredients,
         number: 5,
         instructionsRequired: true,
         sort: "max-used-ingredients",
-        apiKey: api_key,
+        apiKey: api_key
     }
-    if (request.params.diets != "none") {
-        params["diet"] = request.params.diets
-    }
-    if (request.params.allergies != "none") {
-        params["intolerances"] = request.params.allergies
+    params = {
+        ...params,
+        ...(request.query.ingredients && { includeIngredients: request.query.ingredients }),
+        ...(request.query.diet && { diet: request.query.diet }),
+        ...(request.query.allergies && { intolerances: request.query.allergies })
     }
     let recipes_url = "https://api.spoonacular.com/recipes/complexSearch";
     let { data } = await axios(recipes_url, { params })
@@ -39,25 +37,6 @@ app.get('/apirecipeinfo/:recipeid', async (request, response) => {
         apiKey: api_key
     }
     let recipes_url = `https://api.spoonacular.com/recipes/${request.params.recipeid}/information`;
-    let { data } = await axios(recipes_url, { params })
-    response.json(data);
-});
-
-// fetches standard popular recipes
-app.get('/apistdrecipes/:diets/:allergies', async (request, response) => {
-    const params = {
-        apiKey: api_key,
-        number: 5,
-        sort: "popularity",
-        instructionsRequired: true,
-    }
-    if (request.params.diets != "none") {
-        params["diet"] = request.params.diets
-    }
-    if (request.params.allergies != "none") {
-        params["intolerances"] = request.params.allergies
-    }
-    let recipes_url = `https://api.spoonacular.com/recipes/complexSearch`;
     let { data } = await axios(recipes_url, { params })
     response.json(data);
 });

--- a/express-server/app.js
+++ b/express-server/app.js
@@ -13,19 +13,26 @@ app.use(morgan("tiny"))
 app.use(cors())
 
 // fetches best recipes given user food items from API
-app.get('/apiuserrecipes/:ingredients', async (request, response) => {
-    const params = {
-        ingredients: request.params.ingredients,
-        number: 20,
+app.get('/apiuserrecipes/:ingredients/:diets/:allergies', async (request, response) => {
+    let params = {
+        includeIngredients: request.params.ingredients,
+        number: 5,
         instructionsRequired: true,
-        fillIngredients: true,
-        apiKey: api_key
+        sort: "max-used-ingredients",
+        apiKey: api_key,
     }
-    let recipes_url = "https://api.spoonacular.com/recipes/findByIngredients";
+    if (request.params.diets != "none") {
+        params["diet"] = request.params.diets
+    }
+    if (request.params.allergies != "none") {
+        params["intolerances"] = request.params.allergies
+    }
+    let recipes_url = "https://api.spoonacular.com/recipes/complexSearch";
     let { data } = await axios(recipes_url, { params })
     response.json(data);
 });
 
+// TODO: add in recipe information to each recipe so you don't need to create a separate request
 // fetches recipe specific info given recipe id from API
 app.get('/apirecipeinfo/:recipeid', async (request, response) => {
     const params = {
@@ -37,18 +44,22 @@ app.get('/apirecipeinfo/:recipeid', async (request, response) => {
 });
 
 // fetches standard popular recipes
-app.get('/apistdrecipes', async (request, response) => {
+app.get('/apistdrecipes/:diets/:allergies', async (request, response) => {
     const params = {
         apiKey: api_key,
-        number: 20,
-        sort: "random",
-        addRecipeInformation: true,
+        number: 5,
+        sort: "popularity",
         instructionsRequired: true,
-        fillIngredients: true
+    }
+    if (request.params.diets != "none") {
+        params["diet"] = request.params.diets
+    }
+    if (request.params.allergies != "none") {
+        params["intolerances"] = request.params.allergies
     }
     let recipes_url = `https://api.spoonacular.com/recipes/complexSearch`;
     let { data } = await axios(recipes_url, { params })
-    response.json(data.results);
+    response.json(data);
 });
 
 module.exports = app

--- a/src/components/Pantry/Pantry.jsx
+++ b/src/components/Pantry/Pantry.jsx
@@ -32,7 +32,7 @@ export default function Pantry(props) {
   useEffect(() => {
     if (!props.isLoading) {
       var userInfo = props.users.find(u => u.uid === currentUser.uid)
-      setUserProducts(userInfo.data.products)
+      userInfo.data.products && setUserProducts(userInfo.data.products)
     }
   }, [props.isLoading])
   

--- a/src/components/RecipeCard/RecipeCard.jsx
+++ b/src/components/RecipeCard/RecipeCard.jsx
@@ -41,7 +41,7 @@ export default function RecipeCard(props) {
         <img src={props.image} alt={`recipe for ${props.title}`} onClick={() => handleRecipeCardClick(true, props.id)}/>
         <p className="recipe-name">{props.title}</p>
         {/* recipe modal */}
-        <RecipeModal show={recipeModelShow} onHide={() => handleRecipeModal(false)} recipeInfo={recipeInfo}></RecipeModal>
+        <RecipeModal show={recipeModelShow} onHide={() => handleRecipeModal(false)} recipeInfo={recipeInfo} userDiets={props.userDiets}></RecipeModal>
     </div>
   )
 }

--- a/src/components/RecipeModal/RecipeModal.jsx
+++ b/src/components/RecipeModal/RecipeModal.jsx
@@ -1,17 +1,26 @@
 import * as React from "react"
+import { useState } from "react"
 import Modal from "react-bootstrap/Modal"
-import { Container, Row, Col, Button } from "react-bootstrap" 
+import { Container, Row, Col, Button, Alert } from "react-bootstrap" 
 import "./RecipeModal.css"
 
 export default function RecipeModal(props) {
     if (!props.show) {
         return null
     }
-    const { recipeInfo, ...modalProps } = props
+    const { recipeInfo, userDiets, ...modalProps } = props
+    console.log(recipeInfo)
     const validMins = !(recipeInfo.readInMinutes == undefined)
     const validServings = !(recipeInfo.servings == undefined)
     const validIngred = !(recipeInfo.extendedIngredients == undefined)
-    const validSteps = !(recipeInfo.analyzedInstructions == undefined || recipeInfo.analyzedInstructions[0].steps == undefined)
+    const validSteps = !(recipeInfo.analyzedInstructions == undefined || recipeInfo.analyzedInstructions.length == 0 || recipeInfo.analyzedInstructions[0].steps == undefined)
+    const dietsWarning = userDiets.filter(value => !recipeInfo.diets.includes(value)) || []
+    console.log(userDiets)
+    console.log(recipeInfo.diets)
+    var warning
+    dietsWarning 
+      ? warning = (`Caution: ${dietsWarning.join(", ")} dietary restriction(s) are not followed for this recipe`)
+      : warning = ""
     
     return (
       <Modal {...modalProps} scrollable={true} size="lg" aria-labelledby="contained-modal-title-vcenter" centered>
@@ -22,10 +31,13 @@ export default function RecipeModal(props) {
         </Modal.Header>
         <Modal.Body className="show-grid">
           <Container>
+            <Row>
+              {warning && <Alert variant="warning">{warning}</Alert>}
+            </Row>
             {/* first row - recipe overview */}
             <Row className="modal-overview">
               {validMins && (<Col> Total Time: {recipeInfo.readyInMinutes} mins </Col>)}
-              {validServings && (<Col> Servings: {recipeInfo.servings} mins </Col>)} 
+              {validServings && (<Col> Servings: {recipeInfo.servings} </Col>)} 
             </Row>
             {/* recipe content */}
             <Row>

--- a/src/components/RecipeModal/RecipeModal.jsx
+++ b/src/components/RecipeModal/RecipeModal.jsx
@@ -9,14 +9,11 @@ export default function RecipeModal(props) {
         return null
     }
     const { recipeInfo, userDiets, ...modalProps } = props
-    console.log(recipeInfo)
     const validMins = !(recipeInfo.readInMinutes == undefined)
     const validServings = !(recipeInfo.servings == undefined)
     const validIngred = !(recipeInfo.extendedIngredients == undefined)
     const validSteps = !(recipeInfo.analyzedInstructions == undefined || recipeInfo.analyzedInstructions.length == 0 || recipeInfo.analyzedInstructions[0].steps == undefined)
     const dietsWarning = userDiets.filter(value => !recipeInfo.diets.includes(value)) || []
-    console.log(userDiets)
-    console.log(recipeInfo.diets)
     var warning
     dietsWarning 
       ? warning = (`Caution: ${dietsWarning.join(", ")} dietary restriction(s) are not followed for this recipe`)

--- a/src/components/Recipes/Recipes.jsx
+++ b/src/components/Recipes/Recipes.jsx
@@ -15,62 +15,90 @@ export default function Recipes(props) {
   const listStdRecipeUrl = "http://localhost:3001/apistdrecipes"
   const [recipes, setRecipes] = useState([])
   const [userProducts, setUserProducts] = useState([])
+  const [userDiets, setUserDiets] = useState([])
+  const [userAllergies, setUserAllergies] = useState([])
   const [error, setError] = useState("")
+  const [isUserInfoLoading, setIsUserInfoLoading] = useState(true)
+  const [isRecipesLoading, setIsRecipesLoading] = useState(true)
+
+  function clearError() {
+    setError("")
+  }
 
   // update user data once page loads
   useEffect(() => {
     if (!props.isLoading) {
       var userInfo = props.users.find(u => u.uid === currentUser.uid)
-      setUserProducts(userInfo.data.products)
+      userInfo.data.products && setUserProducts(userInfo.data.products)
+      userInfo.data.diets && setUserDiets(userInfo.data.diets)
+      userInfo.data.allergies && setUserAllergies(userInfo.data.allergies)
+      setIsUserInfoLoading(false)
     }
   }, [props.isLoading])
 
   // get best recipe matches with user's food items
   useEffect(() => {
     async function fetchStdRecipes() {
+      clearError()
       try {
-        var { data } = await axios(listStdRecipeUrl)
-        setRecipes(data)
+        let customParams = ""
+        userDiets.length == 0 ? customParams += "/none" : customParams += "/" + userDiets.join(",")
+        userAllergies.length == 0 ? customParams += "/none" : customParams += "/" + userAllergies.join(",")
+
+        var { data } = await axios(listStdRecipeUrl + customParams)
+        setRecipes(data.results)
+        setIsRecipesLoading(false)
       } catch (err) {
+        console.log(err)
         setError(err.message)
       }
     }
 
-    if (!props.isLoading && userProducts === undefined) {
+    if (!isUserInfoLoading && !props.isLoading && userProducts.length == 0) {
       fetchStdRecipes()
     }
-  }, [props.isLoading])
+  }, [isUserInfoLoading, props.isLoading])
 
   // get best recipe matches with user's food items
   useEffect(() => {
     async function fetchUserRecipes() {
       try {
+        clearError()
         // API parameter format: ingredient,+ingredient,+ingredient
-        let ingredientParams = userProducts.map((product) => (product.name)).join(",+")
-        const recipeApiIngredients = listUserRecipeUrl + ingredientParams
+        let customParams = userProducts.map((product) => (product.name)).join(",")
+        userDiets.length == 0 ? customParams += "/none" : customParams += "/" + userDiets.join(",")
+        userAllergies.length == 0 ? customParams += "/none" : customParams += "/" + userAllergies.join(",")
+
+        const recipeApiIngredients = listUserRecipeUrl + customParams
         var { data } = await axios(recipeApiIngredients)
-        setRecipes(data)
+        setRecipes(data.results)
+        setIsRecipesLoading(false)
       } catch (err) {
         setError(err.message)
       }
     }
 
-    if (!props.isLoading && userProducts != undefined && userProducts.length > 0) {
+    if (!isUserInfoLoading && !props.isLoading && userProducts.length > 0) {
       fetchUserRecipes()
     } 
-  }, [props.isLoading, userProducts])
+  }, [isUserInfoLoading, props.isLoading, userProducts])
 
   return (
     <nav className="recipes">
       <h2 className="recipes-heading">Recipes</h2>
       {error && <Alert variant="danger">{error}</Alert>}
-      <div className="recipes-grid">
-        {
-          recipes.map((recipe) => (
-            <RecipeCard key={recipe.id} id={recipe.id} title={recipe.title} image={recipe.image} recipeModelShow={props.recipeModelShow} handleRecipeModal={props.handleRecipeModal} handleRecipeCardClick={props.handleRecipeCardClick} recipeInfo={props.recipeInfo}/>
-          ))
-        }
-      </div>
+      {recipes && recipes.length > 0 
+        ? <div className="recipes-grid">
+          {
+            recipes.map((recipe) => (
+              <RecipeCard key={recipe.id} id={recipe.id} title={recipe.title} image={recipe.image} recipeModelShow={props.recipeModelShow} handleRecipeModal={props.handleRecipeModal} handleRecipeCardClick={props.handleRecipeCardClick} recipeInfo={props.recipeInfo}/>
+            ))
+          }
+        </div>
+        : isRecipesLoading 
+          ? <p>Loading</p>
+          : <p>Please decrease your restrictions</p>
+      }
     </nav>
   )
 }

--- a/src/components/Recipes/Recipes.jsx
+++ b/src/components/Recipes/Recipes.jsx
@@ -15,6 +15,7 @@ export default function Recipes(props) {
   const listStdRecipeUrl = "http://localhost:3001/apistdrecipes"
   const [recipes, setRecipes] = useState([])
   const [userProducts, setUserProducts] = useState([])
+  const [userPrimDiet, setUserPrimDiet] = useState("")
   const [userDiets, setUserDiets] = useState([])
   const [userAllergies, setUserAllergies] = useState([])
   const [error, setError] = useState("")
@@ -30,6 +31,7 @@ export default function Recipes(props) {
     if (!props.isLoading) {
       var userInfo = props.users.find(u => u.uid === currentUser.uid)
       userInfo.data.products && setUserProducts(userInfo.data.products)
+      userInfo.data.primDiet && setUserPrimDiet(userInfo.data.primDiet)
       userInfo.data.diets && setUserDiets(userInfo.data.diets)
       userInfo.data.allergies && setUserAllergies(userInfo.data.allergies)
       setIsUserInfoLoading(false)
@@ -42,7 +44,7 @@ export default function Recipes(props) {
       clearError()
       try {
         let customParams = ""
-        userDiets.length == 0 ? customParams += "/none" : customParams += "/" + userDiets.join(",")
+        userPrimDiet.length == 0 ? customParams += "/none" : customParams += "/" + userPrimDiet
         userAllergies.length == 0 ? customParams += "/none" : customParams += "/" + userAllergies.join(",")
 
         var { data } = await axios(listStdRecipeUrl + customParams)
@@ -66,7 +68,7 @@ export default function Recipes(props) {
         clearError()
         // API parameter format: ingredient,+ingredient,+ingredient
         let customParams = userProducts.map((product) => (product.name)).join(",")
-        userDiets.length == 0 ? customParams += "/none" : customParams += "/" + userDiets.join(",")
+        userPrimDiet.length == 0 ? customParams += "/none" : customParams += "/" + userPrimDiet
         userAllergies.length == 0 ? customParams += "/none" : customParams += "/" + userAllergies.join(",")
 
         const recipeApiIngredients = listUserRecipeUrl + customParams
@@ -91,7 +93,7 @@ export default function Recipes(props) {
         ? <div className="recipes-grid">
           {
             recipes.map((recipe) => (
-              <RecipeCard key={recipe.id} id={recipe.id} title={recipe.title} image={recipe.image} recipeModelShow={props.recipeModelShow} handleRecipeModal={props.handleRecipeModal} handleRecipeCardClick={props.handleRecipeCardClick} recipeInfo={props.recipeInfo}/>
+              <RecipeCard key={recipe.id} id={recipe.id} title={recipe.title} image={recipe.image} userDiets={userDiets}/>
             ))
           }
         </div>


### PR DESCRIPTION
### Commit 1: [Fetch filtered recipes based on user profile]
Changes to the `Recipes.jsx` page:

- fetches user's `diets` and `allergies` from the database
- passes these to the backend by adding a parameter for the diets and parameter for the allergies
- if each one is empty (user has no restrictions) it would pass in `"/none"` so the parameters don't get shifted around
- if still no recipes match the requests (such as only having peanuts in the pantry while having a peanut allergy), `recipes` page will display `"Please decrease restrictions"`. This issue will not occur if the user has peanuts and apples, for example, since it would return recipes with apples (thanks to the `sort` parameter!)

Changes to the app.jsx page:

- the backend now uses `complexSearch` request rather than `findByIngredients` to filter out the diets and allergies. the search will prioritize maximizing the user's products (the `sort` parameter) while adhering to the diets and allergies
- note: `complexSearch` has a different param requirements (such as ingredients are no longer separated by `,+` but by only `,`)


Miscellaneous fixes: found simpler way to only use the `set` function if it exists in the database, or the `set` function would make the state variable `undefined` (fixed `Pantry` page too) -> line 35 in `Pantry.jsx`

Future issue (fix in future commit): API will only take in one dietary restriction (right now, it only regards the first dietary restriction) so I will have a dropdown menu for the highest priority dietary restriction (which will be passed to the API) and then secondary, multiple dietary restrictions which would show up as Alert messages in the modal once the user clicks on the recipe

### Commit 2: [Send only primary diet to API and set other diets as warnings]
Changes to the `SignUpProfile.jsx` page:

- Change to having two dropdown menus (primary diet and secondary diets)
- primary diet dropdown menu can only have one selection (feature of the `Typeahead` component)
- Database now stores primary diet as `primDiet` and secondary diets as `diets`

Changes to the `Recipes` page:

- only send the primary diet info to the API request

Changes to the `RecipeModal` page:

- traverse through user's secondary diets and see what is not included in `recipeInfo`'s `diets` (this contains all the dietary restrictions the recipe follows)
- add these to a warning alert. if recipe looks good, warning will not show up
- misc fix: sometimes `recipeInfo.analyzedInstructions` exists but it could just be an empty array, so account for that

Miscellaneous fixes: realized I was still passing in nonexistent variables and functions as `props` from `Recipes` to `RecipeCard` page (since I previously had all my code in `App.jsx`) so I took those unneeded `props` out

TODO: I forgot to take out the `console.log` statements, so I will do that right before merge (I don't want the code reviews to have too many commits)